### PR TITLE
Flip colors if the Inverse flag is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.8
+
+- Add inverse support (^[7)
+
 ## 1.1.7
 
 - Fix extension not being activated in certain cases

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "publisher": "iliazeus",
   "displayName": "ANSI Colors",
   "description": "ANSI color styling for text documents",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "license": "MIT",
   "repository": {
     "url": "https://github.com/iliazeus/vscode-ansi"

--- a/src/AnsiDecorationProvider.ts
+++ b/src/AnsiDecorationProvider.ts
@@ -141,9 +141,13 @@ export class AnsiDecorationProvider implements TextEditorDecorationProvider {
 
     const style: ansi.Style = JSON.parse(key);
 
+    const inverse = style.attributeFlags & ansi.AttributeFlags.Inverse;
+    const background = inverse ? style.foregroundColor : style.backgroundColor;
+    const foreground = inverse ? style.backgroundColor : style.foregroundColor;
+
     decorationType = window.createTextEditorDecorationType({
-      backgroundColor: convertColor(style.backgroundColor),
-      color: convertColor(style.foregroundColor),
+      backgroundColor: convertColor(background),
+      color: convertColor(foreground),
 
       fontWeight: style.attributeFlags & ansi.AttributeFlags.Bold ? "bold" : undefined,
       fontStyle: style.attributeFlags & ansi.AttributeFlags.Italic ? "italic" : undefined,

--- a/test/basic.ans
+++ b/test/basic.ans
@@ -1,10 +1,23 @@
-[30mblack[0m    [90mbright black[0m     [40mblack[0m    [100mbright black[0m
-[31mred[0m      [91mbright red[0m       [41mred[0m      [101mbright red[0m
-[32mgreen[0m    [92mbright green[0m     [42mgreen[0m    [102mbright green[0m
-[33myellow[0m   [93mbright yellow[0m    [43myellow[0m   [103mbright yellow[0m
-[34mblue[0m     [94mbright blue[0m      [44mblue[0m     [104mbright blue[0m
-[35mmagenta[0m  [95mbright magenta[0m   [45mmagenta[0m  [105mbright magenta[0m
-[36mcyan[0m     [96mbright cyan[0m      [46mcyan[0m     [106mbright cyan[0m
-[37mwhite[0m    [97mbright white[0m     [47mwhite[0m    [107mbright white[0m
+   foreground colors    |   background colors
+-------------------------------------------------
+[30mblack[0m    [90mbright black[0m   | [40mblack[0m    [100mbright black[0m
+[31mred[0m      [91mbright red[0m     | [41mred[0m      [101mbright red[0m
+[32mgreen[0m    [92mbright green[0m   | [42mgreen[0m    [102mbright green[0m
+[33myellow[0m   [93mbright yellow[0m  | [43myellow[0m   [103mbright yellow[0m
+[34mblue[0m     [94mbright blue[0m    | [44mblue[0m     [104mbright blue[0m
+[35mmagenta[0m  [95mbright magenta[0m | [45mmagenta[0m  [105mbright magenta[0m
+[36mcyan[0m     [96mbright cyan[0m    | [46mcyan[0m     [106mbright cyan[0m
+[37mwhite[0m    [97mbright white[0m   | [47mwhite[0m    [107mbright white[0m
 
-[1mbold[0m [2mdim[0m [3mitalic[3m [4munderline[4m
+  inverted foreground   |   inverted background
+-------------------------------------------------
+[7;30mblack[0m    [7;90mbright black[0m   | [7;40mblack[0m    [7;100mbright black[0m
+[7;31mred[0m      [7;91mbright red[0m     | [7;41mred[0m      [7;101mbright red[0m
+[7;32mgreen[0m    [7;92mbright green[0m   | [7;42mgreen[0m    [7;102mbright green[0m
+[7;33myellow[0m   [7;93mbright yellow[0m  | [7;43myellow[0m   [7;103mbright yellow[0m
+[7;34mblue[0m     [7;94mbright blue[0m    | [7;44mblue[0m     [7;104mbright blue[0m
+[7;35mmagenta[0m  [7;95mbright magenta[0m | [7;45mmagenta[0m  [7;105mbright magenta[0m
+[7;36mcyan[0m     [7;96mbright cyan[0m    | [7;46mcyan[0m     [7;106mbright cyan[0m
+[7;37mwhite[0m    [7;97mbright white[0m   | [7;47mwhite[0m    [7;107mbright white[0m
+
+[1mbold[0m [2mdim[0m [3mitalic[0m [4munderline[0m


### PR DESCRIPTION
Support for the ANSI flag (`^[7`) was already present, but not used.
This PR simply flips the usages of `style.foregroundColor` and `style.backgroundColor` if that flag is present.